### PR TITLE
Add a Pause/Resume Feature #1

### DIFF
--- a/Game of Life.py
+++ b/Game of Life.py
@@ -2,14 +2,25 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
-def update(frameNum, img, grid, N):
+N = 100
+ON = 255
+OFF = 0
+vals = [ON, OFF]
+
+grid = np.random.choice(vals, N * N, p=[0.2, 0.8]).reshape(N, N)
+
+pause = [False]
+
+def update(frameNum, img, grid, N, pause):
+    if pause[0]:
+        return img,
     newGrid = grid.copy()
     for i in range(N):
         for j in range(N):
             total = int((grid[i, (j-1)%N] + grid[i, (j+1)%N] +
                          grid[(i-1)%N, j] + grid[(i+1)%N, j] +
                          grid[(i-1)%N, (j-1)%N] + grid[(i-1)%N, (j+1)%N] +
-                         grid[(i+1)%N, (j-1)%N] + grid[(i+1)%N, (j+1)%N])/255)
+                         grid[(i+1)%N, (j-1)%N] + grid[(i+1)%N, (j+1)%N]) / 255)
             if grid[i, j] == ON:
                 if (total < 2) or (total > 3):
                     newGrid[i, j] = OFF
@@ -20,15 +31,13 @@ def update(frameNum, img, grid, N):
     grid[:] = newGrid[:]
     return img,
 
-N = 100
-ON = 255
-OFF = 0
-vals = [ON, OFF]
-
-grid = np.random.choice(vals, N*N, p=[0.2, 0.8]).reshape(N, N)
+def toggle_pause(event):
+    if event.key == ' ':
+        pause[0] = not pause[0]
 
 fig, ax = plt.subplots()
 img = ax.imshow(grid, interpolation='nearest')
-ani = animation.FuncAnimation(fig, update, fargs=(img, grid, N, ), frames=10, interval=50, save_count=50)
+fig.canvas.mpl_connect('key_press_event', toggle_pause)
 
+ani = animation.FuncAnimation(fig, update, fargs=(img, grid, N, pause), frames=10, interval=50, save_count=50)
 plt.show()


### PR DESCRIPTION
1. Added a `pause` state as a mutable list to track the simulation status.  
2. Introduced a `toggle_pause` function to handle keyboard events (spacebar) and switch the `pause` state.  
3. Updated the `update` function to skip grid updates if the simulation is paused.  
4. Linked the `toggle_pause` function to key press events via `mpl_connect`.